### PR TITLE
Use Backstage-provided components instead of Material UI Card + Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "clean": "backstage-cli clean"
   },
   "dependencies": {
-    "@backstage/catalog-model": "^0.4.0",
-    "@backstage/core": "^0.3.0",
+    "@backstage/catalog-model": "^0.7.0",
+    "@backstage/core": "^0.6.0",
     "@material-ui/core": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.45",
     "cross-fetch": "^3.0.6",
@@ -39,15 +39,15 @@
     "react-use": "^15.3.3"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.4.0",
-    "@backstage/dev-utils": "^0.1.3",
-    "@backstage/test-utils": "^0.1.2",
+    "@backstage/cli": "^0.6.0",
+    "@backstage/dev-utils": "^0.1.9",
+    "@backstage/test-utils": "^0.1.6",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.1",
-    "@typescript-eslint/eslint-plugin": "^3.8.0",
-    "@typescript-eslint/parser": "^3.8.0",
+    "@typescript-eslint/eslint-plugin": "^v4.14.0",
+    "@typescript-eslint/parser": "^v4.14.0",
     "esbuild": "^0.6.18",
     "eslint": "^7.6.0",
     "eslint-plugin-react": "^7.20.5",

--- a/src/components/ArgoCDHistoryPage.tsx
+++ b/src/components/ArgoCDHistoryPage.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
 import React from 'react';
+import { Entity } from '@backstage/catalog-model';
 
 // @ts-ignore
 export const ArgoCDHistoryPage = ({ entity: _ }: { entity: Entity }) => {


### PR DESCRIPTION
Hey!

For more visual consistency between this plugin and the rest of the Backstage ecosystem, I suggest using Backstage-provided components instead of the ones provided by Material UI (especially Card + Table).

As a bonus, it also means that the `ArgoCDDetails` component now supports dark theme.

Material UI Card + Table:
![argo-material](https://user-images.githubusercontent.com/66958/107092761-71014a80-6804-11eb-9408-41f4d33c4f4d.png)

Backstage InfoCard + Table:
![argo-backstage](https://user-images.githubusercontent.com/66958/107094289-0b628d80-6807-11eb-9f84-c745154f93b9.png)

Note: I had to move a few things around to make the linters happy.
