### PR TITLE
support for extra provided columns

### DIFF
--- a/src/components/ArgoCDDetailsWidget.tsx
+++ b/src/components/ArgoCDDetailsWidget.tsx
@@ -63,7 +63,7 @@ const State = ({ value }: { value: string }) => {
   );
 };
 
-const OverviewComponent = ({ data }: { data: ArgoCDAppList }) => {
+const OverviewComponent = ({ data, extraColumns }: { data: ArgoCDAppList, extraColumns: TableColumn[] }) => {
   const configApi = useApi(configApiRef);
   const baseUrl = configApi.getOptionalString('argocd.baseUrl')
 
@@ -105,12 +105,12 @@ const OverviewComponent = ({ data }: { data: ArgoCDAppList }) => {
         padding: 'dense',
       }}
       data={data.items}
-      columns={columns}
+      columns={columns.concat(extraColumns)}
     />
   );
 };
 
-const ArgoCDDetails = ({ entity }: { entity: Entity }) => {
+const ArgoCDDetails = ({ entity, extraColumns }: { entity: Entity, extraColumns: TableColumn[] }) => {
   const { url, appName, appSelector, projectName } = useArgoCDAppData({
     entity,
   });
@@ -136,12 +136,12 @@ const ArgoCDDetails = ({ entity }: { entity: Entity }) => {
   }
   if (value) {
     if ((value as ArgoCDAppList).items !== undefined) {
-      return <OverviewComponent data={value as ArgoCDAppList} />;
+      return <OverviewComponent data={value as ArgoCDAppList} extraColumns={extraColumns} />;
     }
     const wrapped: ArgoCDAppList = {
       items: [value as ArgoCDAppDetails],
     };
-    return <OverviewComponent data={wrapped} />;
+    return <OverviewComponent data={wrapped} extraColumns={extraColumns} />;
   }
   return null;
 };
@@ -149,12 +149,12 @@ const ArgoCDDetails = ({ entity }: { entity: Entity }) => {
 /**
  * @deprecated since v0.3.0 you should use new composability API
  */
-export const ArgoCDDetailsWidget = ({ entity }: { entity: Entity }) => {
+export const ArgoCDDetailsWidget = ({ entity, extraColumns }: { entity: Entity, extraColumns?: TableColumn[] }) => {
   return !isArgocdAvailable(entity) ? (
     <MissingAnnotationEmptyState annotation={ARGOCD_ANNOTATION_APP_NAME} />
   ) : (
     <ErrorBoundary>
-      <ArgoCDDetails entity={entity} />
+      <ArgoCDDetails entity={entity} extraColumns={extraColumns || []} />
     </ErrorBoundary>
   );
 };

--- a/src/plugin.test.tsx
+++ b/src/plugin.test.tsx
@@ -22,6 +22,7 @@ import {
   UrlPatternDiscovery,
   configApiRef,
   ConfigReader,
+  TableColumn,
 } from '@backstage/core';
 import { render } from '@testing-library/react';
 import { rest } from 'msw';
@@ -92,6 +93,27 @@ describe('argo-cd', () => {
         </ApiProvider>
       );
       expect(await rendered.findByText('guestbook')).toHaveAttribute('href', 'www.example-argocd-url.com/applications/guestbook');
+    });
+
+    it('should display extra column', async () => {
+      worker.use(
+        rest.get('*', (_, res, ctx) => res(ctx.json(getResponseStub)))
+      );
+
+      const extraColumns: TableColumn[] = [
+        {
+          title: "Repo URL",
+          field: "spec.source.repoURL",
+        },
+      ]
+
+      const rendered = render(
+        <ApiProvider apis={apis}>
+          <ArgoCDDetailsWidget entity={getEntityStub} extraColumns={extraColumns} />
+        </ApiProvider>
+      );
+      expect(await rendered.findByText('Repo URL')).toBeInTheDocument();
+      expect(await rendered.findByText('https://github.com/argoproj/argocd-example-apps')).toBeInTheDocument();
     });
 
     it('should display properly failure status codes', async () => {


### PR DESCRIPTION
Hi,

ArgoCD provides a lot of implementation specific values, for instance a set of revisions for a particular component of an application nested at `spec.source.plugin.env`. These use cases aren't easily generalised so adding a way to hook in custom columns which can process the row data themselves and render the respective data would be ideal. This PR attempts to do that.

Do let me know if there's a nicer way to do this aside from passing it down through all the components, definitely open to discussion on implementation.